### PR TITLE
fixed: block indenting now works properly

### DIFF
--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -27,8 +27,8 @@ function! TerraformIndent(lnum)
   let previndent = indent(prevlnum)
   let thisindent = previndent
 
-  " block open
-  if prevline =~ '[{]\s*$'
+  " block open?
+  if prevline =~ '[\[{]\s*$'
     let thisindent += &sw
   endif
 
@@ -36,7 +36,7 @@ function! TerraformIndent(lnum)
   let thisline = substitute(getline(a:lnum), '//.*$', '', '')
 
   " block close?
-  if thisline =~ '^\s*[}]'
+  if thisline =~ '^\s*[\]}]'
     let thisindent -= &sw
   endif
 

--- a/indent/terraform.vim
+++ b/indent/terraform.vim
@@ -1,13 +1,44 @@
-" Only load this indent file when no other was loaded.
 if exists("b:did_indent")
   finish
 endif
+
 let b:did_indent = 1
 
-setlocal smartindent
+setlocal nolisp
+setlocal autoindent
+setlocal indentexpr=TerraformIndent(v:lnum)
+setlocal indentkeys+=<:>,0=},0=)
 
-" override the tf.vim indent file
-set indentexpr=
+if exists("*TerraformIndent")
+  finish
+endif
 
-" prevent # from being shunted to the first column
-inoremap # X#
+function! TerraformIndent(lnum)
+  " previous non-blank line
+  let prevlnum = prevnonblank(a:lnum-1)
+
+  " beginning of file?
+  if prevlnum == 0
+    return 0
+  endif
+
+  " previous line without comments
+  let prevline = substitute(getline(prevlnum), '//.*$', '', '')
+  let previndent = indent(prevlnum)
+  let thisindent = previndent
+
+  " block open
+  if prevline =~ '[{]\s*$'
+    let thisindent += &sw
+  endif
+
+  " current line without comments
+  let thisline = substitute(getline(a:lnum), '//.*$', '', '')
+
+  " block close?
+  if thisline =~ '^\s*[}]'
+    let thisindent -= &sw
+  endif
+
+  return thisindent
+endfunction


### PR DESCRIPTION
Thanks for your awesome vim script.

I tried to indent .tf files and I was a little unsatisfied about how it (doesn't correctly) indents terraform blocks.

For example if you had

```
block {
    sub_block1 {
    }
    sub_block2 {
    }
}
```

and fixed the whole file's indentation in vim (using = ), sub_block2 would not be properly aligned:

```
block {
    sub_block1 {
    }
        sub_block2 {  // this is wrong
        }
}
```

This patch is a modest attempt to fix this (it doesn't for example properly handle /**/ style comments).
Please let me know if you agree with it.