### PR TITLE
Add *.tfvars to ftdetect

### DIFF
--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,2 +1,2 @@
-au BufRead,BufNewFile *.tf setlocal filetype=terraform
+au BufRead,BufNewFile *.tf,*tfvars setlocal filetype=terraform
 au BufRead,BufNewFile *.tfstate setlocal filetype=javascript


### PR DESCRIPTION
`*.tfvars` is used by Terraform to set variables.
These files use the same syntax as `*.tf`.

ref: https://terraform.io/intro/getting-started/variables.html