### PR TITLE
Syntax highlighting fixes for quoting and functions

### DIFF
--- a/ftdetect/terraform.vim
+++ b/ftdetect/terraform.vim
@@ -1,2 +1,3 @@
 au BufRead,BufNewFile *.tf setlocal filetype=terraform
+au BufRead,BufNewFile *.tfvars setlocal filetype=terraform
 au BufRead,BufNewFile *.tfstate setlocal filetype=javascript

--- a/syntax/terraform.vim
+++ b/syntax/terraform.vim
@@ -34,6 +34,7 @@ syn keyword terraTodo         contained TODO FIXME XXX BUG
 syn cluster terraCommentGroup contains=terraTodo
 syn region  terraComment      start="/\*" end="\*/" contains=@terraCommentGroup,@Spell
 syn region  terraComment      start="#" end="$" contains=@terraCommentGroup,@Spell
+syn region  terraComment      start="//" end="$" contains=@terraCommentGroup,@Spell
 
 syn match  terraResource        /\<resource\>/ nextgroup=terraResourceTypeStr skipwhite
 syn region terraResourceTypeStr start=/"/ end=/"/ contains=terraResourceTypeBI
@@ -55,10 +56,14 @@ syn region terraModuleName start=/"/ end=/"/ nextgroup=terraModuleBlock skipwhit
 """ misc.
 syn match terraValueDec      "\<[0-9]\+\([kKmMgG]b\?\)\?\>"
 syn match terraValueHexaDec  "\<0x[0-9a-f]\+\([kKmMgG]b\?\)\?\>"
-syn match	terraBraces	       "[{}\[\]]"
+syn match terraBraces        "[{}\[\]]"
 
-syn region terraValueString  start=/"/    end=/"/    contains=terraStringInterp
-syn region terraStringInterp matchgroup=terraBrackets start=/\${/  end=/}/ contained
+""" skip \" in strings.
+""" we may also want to pass \\" into a function to escape quotes.
+syn region terraValueString   start=/"/ skip=/\\\+"/ end=/"/ contains=terraStringInterp
+syn region terraStringInterp  matchgroup=terraBrackets start=/\${/ end=/}/ contains=terraValueFunction contained
+"" TODO match keywords here, not a-z+
+syn region terraValueFunction matchgroup=terraBrackets start=/[a-z]\+(/ end=/)/ contains=terraValueString,terraValueFunction contained
 
 hi def link terraComment           Comment
 hi def link terraTodo              Todo
@@ -80,5 +85,6 @@ hi def link terraProvisioner       Structure
 hi def link terraProvisionerName   String
 hi def link terraModule            Structure
 hi def link terraModuleName        String
+hi def link terraValueFunction     Identifier
 
 let b:current_syntax = "terraform"


### PR DESCRIPTION
I wrote this a while back when you weren't maintaining vim-terraform.  Glad to see you're back.

Part of this PR effectively duplicates #6 (still open), since I fixed the ftdetect as well.  However, the nested quotes and function highlighting (and the // comment highlight) are the important parts.

I also removed the resource highlighting completely from my fork (too hard to keep up with), but that's a more opinionated and breaking change so I held it out of this PR.


Original commit message
---

Quoting wouldn't handle backslashed quotes (\") for nesting.  Added
that, and the rarer case of \\" which I found in a function call where I
was attempting to get a literal \" provided to a template.

Also added a rough hack to highlight functions such as split() or join()
differently than variables inside an interpolation (or outside).

Added the comment highlighting for the // comment type.

Added highlighting for tfvars files, using the basic terraform filetype.
This is sufficient to highlight strings and comments, which comprise the
whole tfvars file.